### PR TITLE
chore: delete created_at field from environment type resource

### DIFF
--- a/docs/data-sources/environment_type.md
+++ b/docs/data-sources/environment_type.md
@@ -27,6 +27,5 @@ data "humanitec_environment_type" "environment_type" {
 
 ### Read-Only
 
-- `created_at` (String) Environment Type creation timestamp
 - `display_name` (String) Environment Type display name
 - `uuid` (String) Environment Type UUID

--- a/docs/resources/environment_type.md
+++ b/docs/resources/environment_type.md
@@ -32,7 +32,6 @@ resource "humanitec_environment_type" "environment_type" {
 
 ### Read-Only
 
-- `created_at` (String) The creation timestamp of the Environment Type.
 - `uuid` (String) The UUID of the Environment Type.
 
 ## Import

--- a/internal/provider/environment_type_data_source.go
+++ b/internal/provider/environment_type_data_source.go
@@ -32,7 +32,6 @@ type EnvironmentTypeDataSourceModel struct {
 	Id          types.String `tfsdk:"id"`
 	DisplayName types.String `tfsdk:"display_name"`
 	Uuid        types.String `tfsdk:"uuid"`
-	CreatedAt   types.String `tfsdk:"created_at"`
 }
 
 func (d *EnvironmentTypeDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -61,10 +60,6 @@ func (d *EnvironmentTypeDataSource) Schema(ctx context.Context, req datasource.S
 			},
 			"uuid": schema.StringAttribute{
 				MarkdownDescription: "Environment Type UUID",
-				Computed:            true,
-			},
-			"created_at": schema.StringAttribute{
-				MarkdownDescription: "Environment Type creation timestamp",
 				Computed:            true,
 			},
 		},
@@ -116,7 +111,6 @@ func (d *EnvironmentTypeDataSource) Read(ctx context.Context, req datasource.Rea
 	data.Id = types.StringValue(environmentType.Id)
 	data.DisplayName = types.StringValue(environmentType.DisplayName)
 	data.Uuid = types.StringValue(environmentType.Uuid.String())
-	data.CreatedAt = types.StringValue(environmentType.CreatedAt.String())
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/environment_type_resource.go
+++ b/internal/provider/environment_type_resource.go
@@ -35,7 +35,6 @@ type EnvironmentTypeResourceModel struct {
 	Id          types.String `tfsdk:"id"`
 	DisplayName types.String `tfsdk:"display_name"`
 	Uuid        types.String `tfsdk:"uuid"`
-	CreatedAt   types.String `tfsdk:"created_at"`
 }
 
 func (r *EnvironmentTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -74,13 +73,6 @@ func (r *EnvironmentTypeResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"uuid": schema.StringAttribute{
 				MarkdownDescription: "The UUID of the Environment Type.",
-				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"created_at": schema.StringAttribute{
-				MarkdownDescription: "The creation timestamp of the Environment Type.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -214,6 +206,5 @@ func toEnvironmentTypeModel(item canyoncp.EnvironmentType) EnvironmentTypeResour
 		Id:          types.StringValue(item.Id),
 		Uuid:        types.StringValue(item.Uuid.String()),
 		DisplayName: types.StringValue(item.DisplayName),
-		CreatedAt:   types.StringValue(item.CreatedAt.String()),
 	}
 }

--- a/internal/provider/environment_type_resource_test.go
+++ b/internal/provider/environment_type_resource_test.go
@@ -33,11 +33,6 @@ func TestAccEnvironmentTypeResource(t *testing.T) {
 						tfjsonpath.New("uuid"),
 						knownvalue.NotNull(),
 					),
-					statecheck.ExpectKnownValue(
-						"humanitec_environment_type.test",
-						tfjsonpath.New("created_at"),
-						knownvalue.NotNull(),
-					),
 				},
 			},
 			// Update testing
@@ -57,11 +52,6 @@ func TestAccEnvironmentTypeResource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"humanitec_environment_type.test",
 						tfjsonpath.New("uuid"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"humanitec_environment_type.test",
-						tfjsonpath.New("created_at"),
 						knownvalue.NotNull(),
 					),
 				},


### PR DESCRIPTION
This removes created_at field from environment type resource