### PR TITLE
fix(kubernetes_runner): keep auth value configured by the state

### DIFF
--- a/docs/resources/kubernetes_runner.md
+++ b/docs/resources/kubernetes_runner.md
@@ -73,7 +73,7 @@ Required:
 
 Required:
 
-- `auth` (Attributes, Sensitive) The authentication configuration for the Kubernetes Runner cluster. (see [below for nested schema](#nestedatt--runner_configuration--cluster--auth))
+- `auth` (Attributes) The authentication configuration for the Kubernetes Runner cluster. (see [below for nested schema](#nestedatt--runner_configuration--cluster--auth))
 - `cluster_data` (Attributes) The cluster data for the Kubernetes Runner cluster. (see [below for nested schema](#nestedatt--runner_configuration--cluster--cluster_data))
 
 <a id="nestedatt--runner_configuration--cluster--auth"></a>
@@ -81,9 +81,9 @@ Required:
 
 Optional:
 
-- `client_certificate_data` (String) The client certificate data for the Kubernetes Runner cluster.
-- `client_key_data` (String) The client key data for the Kubernetes Runner cluster.
-- `service_account_token` (String) The service account token for the Kubernetes Runner cluster.
+- `client_certificate_data` (String, Sensitive) The client certificate data for the Kubernetes Runner cluster.
+- `client_key_data` (String, Sensitive) The client key data for the Kubernetes Runner cluster.
+- `service_account_token` (String, Sensitive) The service account token for the Kubernetes Runner cluster.
 
 
 <a id="nestedatt--runner_configuration--cluster--cluster_data"></a>

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 
 )
 
-require github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0 // indirect
+require github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
@@ -84,7 +84,7 @@ require (
 	google.golang.org/grpc v1.72.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen

--- a/internal/provider/kubernetes_runner_resource.go
+++ b/internal/provider/kubernetes_runner_resource.go
@@ -183,22 +183,21 @@ func (r *KubernetesRunnerResource) Schema(ctx context.Context, req resource.Sche
 							"auth": schema.SingleNestedAttribute{
 								MarkdownDescription: "The authentication configuration for the Kubernetes Runner cluster.",
 								Required:            true,
-								Sensitive:           true,
 								Attributes: map[string]schema.Attribute{
 									"client_certificate_data": schema.StringAttribute{
 										MarkdownDescription: "The client certificate data for the Kubernetes Runner cluster.",
 										Optional:            true,
-										Computed:            true,
+										Sensitive:           true,
 									},
 									"client_key_data": schema.StringAttribute{
 										MarkdownDescription: "The client key data for the Kubernetes Runner cluster.",
 										Optional:            true,
-										Computed:            true,
+										Sensitive:           true,
 									},
 									"service_account_token": schema.StringAttribute{
 										MarkdownDescription: "The service account token for the Kubernetes Runner cluster.",
 										Optional:            true,
-										Computed:            true,
+										Sensitive:           true,
 									},
 								},
 							},
@@ -456,29 +455,28 @@ func parseKubernetesRunnerConfigurationResponse(ctx context.Context, k8sRunnerCo
 	runnerConfig.Cluster.ClusterData.Server = types.StringValue(k8sRunnerConfiguration.Cluster.ClusterData.Server)
 	runnerConfig.Cluster.ClusterData.ProxyUrl = types.StringPointerValue(k8sRunnerConfiguration.Cluster.ClusterData.ProxyUrl)
 
-	// Preserve auth fields from existing data (sensitive values are returned as placeholder by API)
-	// If API returns the placeholder but the model has a real value, we should use the model value otherwise placeholder is fine.
-	if k8sRunnerConfiguration.Cluster.Auth.ClientCertificateData == nil {
-		runnerConfig.Cluster.Auth.ClientCertificateData = types.StringNull()
-	} else {
-		if runnerConfig.Cluster.Auth.ClientCertificateData.IsNull() || runnerConfig.Cluster.Auth.ClientCertificateData.IsUnknown() {
+	// Handle auth fields: these are sensitive so preserve the user's configuration unless they are unknown
+	if runnerConfig.Cluster.Auth.ClientCertificateData.IsUnknown() || runnerConfig.Cluster.Auth.ClientCertificateData.IsNull() {
+		if k8sRunnerConfiguration.Cluster.Auth.ClientCertificateData != nil {
 			runnerConfig.Cluster.Auth.ClientCertificateData = types.StringValue(*k8sRunnerConfiguration.Cluster.Auth.ClientCertificateData)
+		} else {
+			runnerConfig.Cluster.Auth.ClientCertificateData = types.StringNull()
 		}
 	}
 
-	if k8sRunnerConfiguration.Cluster.Auth.ClientKeyData == nil {
-		runnerConfig.Cluster.Auth.ClientKeyData = types.StringNull()
-	} else {
-		if runnerConfig.Cluster.Auth.ClientKeyData.IsNull() || runnerConfig.Cluster.Auth.ClientKeyData.IsUnknown() {
+	if runnerConfig.Cluster.Auth.ClientKeyData.IsUnknown() || runnerConfig.Cluster.Auth.ClientKeyData.IsNull() {
+		if k8sRunnerConfiguration.Cluster.Auth.ClientKeyData != nil {
 			runnerConfig.Cluster.Auth.ClientKeyData = types.StringValue(*k8sRunnerConfiguration.Cluster.Auth.ClientKeyData)
+		} else {
+			runnerConfig.Cluster.Auth.ClientKeyData = types.StringNull()
 		}
 	}
 
-	if k8sRunnerConfiguration.Cluster.Auth.ServiceAccountToken == nil {
-		runnerConfig.Cluster.Auth.ServiceAccountToken = types.StringNull()
-	} else {
-		if runnerConfig.Cluster.Auth.ServiceAccountToken.IsNull() || runnerConfig.Cluster.Auth.ServiceAccountToken.IsUnknown() {
+	if runnerConfig.Cluster.Auth.ServiceAccountToken.IsUnknown() || runnerConfig.Cluster.Auth.ServiceAccountToken.IsNull() {
+		if k8sRunnerConfiguration.Cluster.Auth.ServiceAccountToken != nil {
 			runnerConfig.Cluster.Auth.ServiceAccountToken = types.StringValue(*k8sRunnerConfiguration.Cluster.Auth.ServiceAccountToken)
+		} else {
+			runnerConfig.Cluster.Auth.ServiceAccountToken = types.StringNull()
 		}
 	}
 


### PR DESCRIPTION
While testing my previous changes, I realized that no drift was detected if a field in `runner_configuration.cluster.auth` was removed.
This was related to a schema issue together with a problem with parsing the response from the API.

This should fix these problems!