### PR TITLE
fix: loading hctl config file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,15 @@ require (
 
 )
 
-require github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
+require (
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -188,7 +188,7 @@ func loadClientConfig(ctx context.Context, data HumanitecProviderModel, diagnost
 	// THIRD - we fall back to shared implicit config file
 	if data.ConfigFilePath.IsNull() {
 		if p, err := getConfigFilePath(); err != nil {
-			diagnostics.AddWarning(HUM_PROVIDER_ERR, err.Error())
+			tflog.Debug(ctx, "skipping implicit hctl config file load: "+err.Error())
 		} else if cfg, err := readConfigFile(p); err != nil {
 			diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Failed to read config file '%s': %s", p, err))
 		} else {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"gopkg.in/yaml.v3"
 
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
@@ -132,15 +133,16 @@ func readConfigFile(path string) (Config, error) {
 }
 
 func getConfigFilePath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	homeDirPath, _ := os.UserHomeDir()
+	homeDirPath = filepath.Join(homeDirPath, ".config", "hctl", "config.yaml")
+	cfgDirPath, _ := os.UserConfigDir()
+	cfgDirPath = filepath.Join(cfgDirPath, "hctl", "config.yaml")
+	if _, err := os.Stat(cfgDirPath); err == nil {
+		return cfgDirPath, nil
+	} else if _, err := os.Stat(homeDirPath); err == nil {
+		return homeDirPath, nil
 	}
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		configDir = filepath.Join(homeDir, ".config")
-	}
-	return filepath.Join(configDir, "hctl", "config.yaml"), nil
+	return "", fmt.Errorf("failed to find hctl config file path: neither %s nor %s exists", cfgDirPath, homeDirPath)
 }
 
 func (p *HumanitecProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -161,11 +163,13 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 		if cfg, err := readConfigFile(p); err != nil {
 			resp.Diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Failed to read config file '%s': %s", p, err))
 		} else {
-			if cfg.ApiUrl != "" {
+			if apiUrl == "" && cfg.ApiUrl != "" {
 				apiUrl = cfg.ApiUrl
-			} else if cfg.DefaultOrg != "" {
+			}
+			if orgId == "" && cfg.DefaultOrg != "" {
 				orgId = cfg.DefaultOrg
-			} else if cfg.Token != "" {
+			}
+			if authToken == "" && cfg.Token != "" {
 				authToken = cfg.Token
 			}
 		}
@@ -173,12 +177,15 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 
 	// SECOND - we fall back to environment variables
 	if v := os.Getenv(HUM_API_URL_ENV_VAR); apiUrl == "" && v != "" {
+		tflog.Debug(ctx, "using platform-orchestrator api url from environment variable")
 		apiUrl = v
 	}
 	if v := os.Getenv(HUM_ORG_ID_ENV_VAR); orgId == "" && v != "" {
+		tflog.Debug(ctx, "using platform-orchestrator org id from environment variable")
 		orgId = v
 	}
 	if v := os.Getenv(HUM_AUTH_TOKEN_ENV_VAR); authToken == "" && v != "" {
+		tflog.Debug(ctx, "using platform-orchestrator auth token from environment variable")
 		authToken = v
 	}
 
@@ -191,11 +198,16 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 				resp.Diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Failed to read config file '%s': %s", p, err))
 			}
 		} else {
-			if cfg.ApiUrl != "" {
+			if apiUrl == "" && cfg.ApiUrl != "" {
+				tflog.Debug(ctx, "using platform-orchestrator api url from hctl config file")
 				apiUrl = cfg.ApiUrl
-			} else if cfg.DefaultOrg != "" {
+			}
+			if orgId == "" && cfg.DefaultOrg != "" {
+				tflog.Debug(ctx, "using platform-orchestrator org id from hctl config file")
 				orgId = cfg.DefaultOrg
-			} else if cfg.Token != "" {
+			}
+			if authToken == "" && cfg.Token != "" {
+				tflog.Debug(ctx, "using platform-orchestrator auth token from hctl config file")
 				authToken = cfg.Token
 			}
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -157,15 +157,15 @@ func loadClientConfig(ctx context.Context, data HumanitecProviderModel, diagnost
 			diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Failed to read config file '%s': %s", p, err))
 		} else {
 			if apiUrl == "" && cfg.ApiUrl != "" {
-				tflog.Debug(ctx, "using platform-orchestrator api url from explicit hctl config file")
+				tflog.Debug(ctx, "using platform-orchestrator api url from explicit hctl config file", map[string]interface{}{"path": p})
 				apiUrl = cfg.ApiUrl
 			}
 			if orgId == "" && cfg.DefaultOrg != "" {
-				tflog.Debug(ctx, "using platform-orchestrator org id from explicit hctl config file")
+				tflog.Debug(ctx, "using platform-orchestrator org id from explicit hctl config file", map[string]interface{}{"path": p})
 				orgId = cfg.DefaultOrg
 			}
 			if authToken == "" && cfg.Token != "" {
-				tflog.Debug(ctx, "using platform-orchestrator auth token from explicit hctl config file")
+				tflog.Debug(ctx, "using platform-orchestrator auth token from explicit hctl config file", map[string]interface{}{"path": p})
 				authToken = cfg.Token
 			}
 		}
@@ -193,15 +193,15 @@ func loadClientConfig(ctx context.Context, data HumanitecProviderModel, diagnost
 			diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Failed to read config file '%s': %s", p, err))
 		} else {
 			if apiUrl == "" && cfg.ApiUrl != "" {
-				tflog.Debug(ctx, "using platform-orchestrator api url from implicit hctl config file")
+				tflog.Debug(ctx, "using platform-orchestrator api url from implicit hctl config file", map[string]interface{}{"path": p})
 				apiUrl = cfg.ApiUrl
 			}
 			if orgId == "" && cfg.DefaultOrg != "" {
-				tflog.Debug(ctx, "using platform-orchestrator org id from implicit hctl config file")
+				tflog.Debug(ctx, "using platform-orchestrator org id from implicit hctl config file", map[string]interface{}{"path": p})
 				orgId = cfg.DefaultOrg
 			}
 			if authToken == "" && cfg.Token != "" {
-				tflog.Debug(ctx, "using platform-orchestrator auth token from implicit hctl config file")
+				tflog.Debug(ctx, "using platform-orchestrator auth token from implicit hctl config file", map[string]interface{}{"path": p})
 				authToken = cfg.Token
 			}
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -140,7 +140,7 @@ func getConfigFilePath() (string, error) {
 	cfgDirPath = filepath.Join(cfgDirPath, "hctl", "config.yaml")
 	if _, err := os.Stat(cfgDirPath); err == nil {
 		return cfgDirPath, nil
-	} else if _, err := os.Stat(homeDirPath); err == nil {
+	} else if _, err = os.Stat(homeDirPath); err == nil {
 		return homeDirPath, nil
 	}
 	return "", fmt.Errorf("failed to find hctl config file path: neither %s nor %s exists", cfgDirPath, homeDirPath)
@@ -208,6 +208,7 @@ func loadClientConfig(ctx context.Context, data HumanitecProviderModel, diagnost
 	}
 
 	if apiUrl == "" {
+		tflog.Debug(ctx, "using default platform-orchestrator api url")
 		apiUrl = HUM_DEFAULT_API_URL
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -83,26 +83,9 @@ func TestLoadClientConfig_with_file(t *testing.T) {
 	assert.Empty(t, d.Warnings())
 }
 
-func overrideEnvVarForTest(t *testing.T, key, value string) {
-	t.Helper()
-	existing, existed := os.LookupEnv(key)
-	if value == "" {
-		require.NoError(t, os.Unsetenv(key))
-	} else {
-		require.NoError(t, os.Setenv(key, value))
-	}
-	t.Cleanup(func() {
-		if existed {
-			require.NoError(t, os.Setenv(key, existing))
-		} else {
-			require.NoError(t, os.Unsetenv(key))
-		}
-	})
-}
-
 func TestLoadClientConfig_with_env(t *testing.T) {
-	overrideEnvVarForTest(t, HUM_ORG_ID_ENV_VAR, "another-org")
-	overrideEnvVarForTest(t, HUM_AUTH_TOKEN_ENV_VAR, "a-token")
+	t.Setenv(HUM_ORG_ID_ENV_VAR, "another-org")
+	t.Setenv(HUM_AUTH_TOKEN_ENV_VAR, "a-token")
 	d := new(diag.Diagnostics)
 	u, o, a := loadClientConfig(t.Context(), HumanitecProviderModel{}, d)
 	assert.Equal(t, "https://api.humanitec.dev", u)
@@ -114,8 +97,8 @@ func TestLoadClientConfig_with_env(t *testing.T) {
 
 func TestLoadClientConfig_with_fallback_file(t *testing.T) {
 	td := t.TempDir()
-	overrideEnvVarForTest(t, "XDG_CONFIG_HOME", "")
-	overrideEnvVarForTest(t, "HOME", td)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", td)
 	cd, _ := os.UserConfigDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(cd, "hctl"), 0700))
 	tf := filepath.Join(cd, "hctl", "config.yaml")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -54,7 +54,15 @@ func NewPlatformOrchestratorControlPlaneClient(t *testing.T) *canyoncp.ClientWit
 	return cpc
 }
 
+func clearEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(HUM_API_URL_ENV_VAR, "")
+	t.Setenv(HUM_ORG_ID_ENV_VAR, "")
+	t.Setenv(HUM_AUTH_TOKEN_ENV_VAR, "")
+}
+
 func TestLoadClientConfig_basic(t *testing.T) {
+	clearEnv(t)
 	d := new(diag.Diagnostics)
 	u, o, a := loadClientConfig(t.Context(), HumanitecProviderModel{
 		ApiUrl:    types.StringValue("https://some-api.com"),
@@ -69,6 +77,7 @@ func TestLoadClientConfig_basic(t *testing.T) {
 }
 
 func TestLoadClientConfig_with_file(t *testing.T) {
+	clearEnv(t)
 	tf := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(tf, []byte(`{"default_org_id": "some-org", "token": "some-token"}`), 0600))
 
@@ -85,6 +94,7 @@ func TestLoadClientConfig_with_file(t *testing.T) {
 }
 
 func TestLoadClientConfig_with_env(t *testing.T) {
+	clearEnv(t)
 	t.Setenv(HUM_ORG_ID_ENV_VAR, "another-org")
 	t.Setenv(HUM_AUTH_TOKEN_ENV_VAR, "a-token")
 	d := new(diag.Diagnostics)
@@ -97,6 +107,7 @@ func TestLoadClientConfig_with_env(t *testing.T) {
 }
 
 func TestLoadClientConfig_with_fallback_file(t *testing.T) {
+	clearEnv(t)
 	td := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", td)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -100,11 +101,14 @@ func TestLoadClientConfig_with_fallback_file(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", td)
 	cd, _ := os.UserConfigDir()
+	require.Contains(t, cd, td)
 	require.NoError(t, os.MkdirAll(filepath.Join(cd, "hctl"), 0700))
 	tf := filepath.Join(cd, "hctl", "config.yaml")
 	require.NoError(t, os.WriteFile(tf, []byte(`{"default_org_id": "some-org", "token": "some-token"}`), 0600))
 	d := new(diag.Diagnostics)
-	u, o, a := loadClientConfig(t.Context(), HumanitecProviderModel{}, d)
+
+	ctx := tflogtest.RootLogger(t.Context(), os.Stdout)
+	u, o, a := loadClientConfig(ctx, HumanitecProviderModel{}, d)
 	assert.Equal(t, "https://api.humanitec.dev", u)
 	assert.Equal(t, "some-org", o)
 	assert.Equal(t, "some-token", a)


### PR DESCRIPTION
The existing implementation was pretty broken and was lacking tests!

I found this when working on the AWS workshop, I kept getting errors like "While configuring the provider, the Auth token was not found in the HUMANITEC_AUTH_TOKEN environment variable or provider configuration block auth_token attribute." when I was clearly authenticated with hctl. This was because the existing code was using if-else blocks and wasn't checking for previously set values and so was overriding things.