### PR TITLE
feat: remove basic auth

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"maps"
 	"net/http"
@@ -45,13 +44,6 @@ const (
 	DefaultAsyncPollInterval = time.Second * 3
 	DefaultAsyncTimeout      = time.Minute * 20
 )
-
-// isBase64Encoded checks if a string is base64 encoded.
-func isBase64Encoded(s string) bool {
-	// Try to decode the string as base64
-	_, err := base64.StdEncoding.DecodeString(s)
-	return err == nil
-}
 
 // Ensure HumanitecProvider satisfies various provider interfaces.
 var _ provider.Provider = &HumanitecProvider{}
@@ -243,12 +235,7 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 
 	extraHeaders := make(http.Header)
 	if authToken != "" {
-		// For now we support temporary Basic authentication with OrgId as a username and the token as a password
-		if isBase64Encoded(authToken) {
-			extraHeaders.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(orgId+":"+authToken)))
-		} else {
-			extraHeaders.Set("Authorization", "Bearer "+authToken)
-		}
+		extraHeaders.Set("Authorization", "Bearer "+authToken)
 	} else if u.Hostname() == "localhost" {
 		// For the local version, our auth is to just set the 'From' header directly.
 		extraHeaders.Set("From", uuid.Nil.String())


### PR DESCRIPTION
This PR removes the Basic Authentication feature. The backend no longer supports Basic Auth, and keeping it in the client causes issues where some Bearer tokens are incorrectly treated as Basic due to the isBasic64encoded function