### PR TITLE
fix: handle 404 on read failure

### DIFF
--- a/internal/provider/environment_data_source.go
+++ b/internal/provider/environment_data_source.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
@@ -127,8 +128,9 @@ func (d *EnvironmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
+	if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment with ID %s not found in project %s", data.Id.ValueString(), data.ProjectId.ValueString()))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -252,12 +252,6 @@ func (r *EnvironmentResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment with ID %s not found in project %s", data.Id.ValueString(), data.ProjectId.ValueString()))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update environment, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -218,8 +218,8 @@ func (r *EnvironmentResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment with ID %s not found in project %s", data.Id.ValueString(), data.ProjectId.ValueString()))
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment with ID %s not found in project %s", data.Id.ValueString(), data.ProjectId.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -252,7 +252,7 @@ func (r *EnvironmentResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
+	if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment with ID %s not found in project %s", data.Id.ValueString(), data.ProjectId.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/environment_type_data_source.go
+++ b/internal/provider/environment_type_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -98,6 +99,12 @@ func (d *EnvironmentTypeDataSource) Read(ctx context.Context, req datasource.Rea
 	httpResp, err := d.cpClient.GetEnvironmentTypeWithResponse(ctx, d.orgId, data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read environment type, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment type with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/environment_type_resource.go
+++ b/internal/provider/environment_type_resource.go
@@ -186,12 +186,6 @@ func (r *EnvironmentTypeResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment Type with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update environment type, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/kubernetes_agent_runner_data_source.go
+++ b/internal/provider/kubernetes_agent_runner_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -145,6 +146,12 @@ func (d *KubernetesAgentRunnerDataSource) Read(ctx context.Context, req datasour
 	httpResp, err := d.cpClient.GetRunnerWithResponse(ctx, d.orgId, data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read kubernetes agent runner, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Kubernetes agent runner with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/kubernetes_agent_runner_resource.go
+++ b/internal/provider/kubernetes_agent_runner_resource.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 	"terraform-provider-humanitec-v2/internal/ref"
 
@@ -262,6 +264,12 @@ func (r *KubernetesAgentRunnerResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", data.Id.ValueString()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read runner, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return
@@ -309,6 +317,12 @@ func (r *KubernetesAgentRunnerResource) Update(ctx context.Context, req resource
 	httpResp, err := r.cpClient.UpdateRunnerWithResponse(ctx, r.orgId, id, updateBody)
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to update runner, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", id))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/kubernetes_agent_runner_resource.go
+++ b/internal/provider/kubernetes_agent_runner_resource.go
@@ -320,12 +320,6 @@ func (r *KubernetesAgentRunnerResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", id))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update runner, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/kubernetes_eks_runner_data_source.go
+++ b/internal/provider/kubernetes_eks_runner_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -173,6 +174,12 @@ func (d *KubernetesEksRunnerDataSource) Read(ctx context.Context, req datasource
 	httpResp, err := d.cpClient.GetRunnerWithResponse(ctx, d.orgId, data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read kubernetes eks runner, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Kubernetes eks runner with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/kubernetes_eks_runner_resource.go
+++ b/internal/provider/kubernetes_eks_runner_resource.go
@@ -395,12 +395,6 @@ func (r *KubernetesEksRunnerResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", id))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update runner, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/kubernetes_gke_runner_data_source.go
+++ b/internal/provider/kubernetes_gke_runner_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -182,6 +183,12 @@ func (d *KubernetesGkeRunnerDataSource) Read(ctx context.Context, req datasource
 	httpResp, err := d.cpClient.GetRunnerWithResponse(ctx, d.orgId, data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read kubernetes gke runner, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Kubernetes gke runner with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/kubernetes_gke_runner_resource.go
+++ b/internal/provider/kubernetes_gke_runner_resource.go
@@ -390,12 +390,6 @@ func (r *KubernetesGkeRunnerResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", id))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update runner, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/kubernetes_gke_runner_resource.go
+++ b/internal/provider/kubernetes_gke_runner_resource.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 	"terraform-provider-humanitec-v2/internal/ref"
 
@@ -332,6 +334,12 @@ func (r *KubernetesGkeRunnerResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", data.Id.ValueString()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read runner, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return
@@ -379,6 +387,12 @@ func (r *KubernetesGkeRunnerResource) Update(ctx context.Context, req resource.U
 	httpResp, err := r.cpClient.UpdateRunnerWithResponse(ctx, r.orgId, id, updateBody)
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to update runner, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", id))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/kubernetes_runner_data_source.go
+++ b/internal/provider/kubernetes_runner_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -184,6 +185,12 @@ func (d *KubernetesRunnerDataSource) Read(ctx context.Context, req datasource.Re
 	httpResp, err := d.cpClient.GetRunnerWithResponse(ctx, d.orgId, data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read kubernetes runner, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Kubernetes runner with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/kubernetes_runner_resource.go
+++ b/internal/provider/kubernetes_runner_resource.go
@@ -399,12 +399,6 @@ func (r *KubernetesRunnerResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner with ID %s not found, assuming it has been deleted.", id))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update runner, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/module_data_source.go
+++ b/internal/provider/module_data_source.go
@@ -205,6 +205,12 @@ func (d *ModuleDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != http.StatusOK {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read module, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/module_resource.go
+++ b/internal/provider/module_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
@@ -398,6 +399,12 @@ func (r *ModuleResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module with ID %s not found, assuming it has been deleted.", data.Id.ValueString()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read module, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return
@@ -471,6 +478,12 @@ func (r *ModuleResource) Update(ctx context.Context, req resource.UpdateRequest,
 	httpResp, err := r.cpClient.UpdateModuleWithResponse(ctx, r.orgId, id, updateBody)
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to update module, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module with ID %s not found, assuming it has been deleted.", id))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/module_resource.go
+++ b/internal/provider/module_resource.go
@@ -481,12 +481,6 @@ func (r *ModuleResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module with ID %s not found, assuming it has been deleted.", id))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update module, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/module_rule_data_source.go
+++ b/internal/provider/module_rule_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/google/uuid"
@@ -115,6 +116,12 @@ func (d *ModuleRuleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	httpResp, err := d.cpClient.GetModuleRuleInOrgWithResponse(ctx, d.orgId, uuid.MustParse(data.Id.ValueString()))
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read module rule, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module rule with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/module_rule_data_source.go
+++ b/internal/provider/module_rule_data_source.go
@@ -119,8 +119,8 @@ func (d *ModuleRuleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
-		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module rule with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module rule with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/module_rule_resource.go
+++ b/internal/provider/module_rule_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 	"terraform-provider-humanitec-v2/internal/ref"
@@ -176,7 +177,7 @@ func (r *ModuleRuleResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
+	if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module rule with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/module_rule_resource.go
+++ b/internal/provider/module_rule_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 	"terraform-provider-humanitec-v2/internal/ref"
 
@@ -172,6 +173,12 @@ func (r *ModuleRuleResource) Read(ctx context.Context, req resource.ReadRequest,
 	httpResp, err := r.cpClient.GetModuleRuleInOrgWithResponse(ctx, r.orgId, uuid.MustParse(data.Id.ValueString()))
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Unable to read module rule, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module rule with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/project_data_source.go
+++ b/internal/provider/project_data_source.go
@@ -112,6 +112,12 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Project with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != http.StatusOK {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read project, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
@@ -163,6 +164,12 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	httpResp, err := r.cpClient.GetProjectWithResponse(ctx, r.orgId, data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Unable to read project, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Project with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/provider_data_source.go
+++ b/internal/provider/provider_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -121,6 +122,12 @@ func (d *ProviderDataSource) Read(ctx context.Context, req datasource.ReadReques
 	httpResp, err := d.cpClient.GetModuleProviderWithResponse(ctx, d.orgId, data.ProviderType.ValueString(), data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read provider, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Provider with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/provider_resource.go
+++ b/internal/provider/provider_resource.go
@@ -243,12 +243,6 @@ func (r *ProviderResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module provider with ID %s not found, assuming it has been deleted.", id))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update module, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/provider_resource.go
+++ b/internal/provider/provider_resource.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 	"terraform-provider-humanitec-v2/internal/ref"
 
@@ -195,6 +197,12 @@ func (r *ProviderResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module provider with ID %s not found, assuming it has been deleted.", data.Id.ValueString()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read module provider, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return
@@ -232,6 +240,12 @@ func (r *ProviderResource) Update(ctx context.Context, req resource.UpdateReques
 	httpResp, err := r.cpClient.UpdateModuleProviderWithResponse(ctx, r.orgId, providerType, id, updateBody)
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to update module provider, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Module provider with ID %s not found, assuming it has been deleted.", id))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/resource_type_data_source.go
+++ b/internal/provider/resource_type_data_source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -106,6 +107,12 @@ func (d *ResourceTypeDataSource) Read(ctx context.Context, req datasource.ReadRe
 	httpResp, err := d.cpClient.GetResourceTypeWithResponse(ctx, d.orgId, data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read resource type, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == 404 {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Resource type with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/resource_type_data_source.go
+++ b/internal/provider/resource_type_data_source.go
@@ -110,7 +110,7 @@ func (d *ResourceTypeDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
+	if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Resource type with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/resource_type_resource.go
+++ b/internal/provider/resource_type_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
@@ -218,7 +219,7 @@ func (r *ResourceTypeResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
+	if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Resource type with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/resource_type_resource.go
+++ b/internal/provider/resource_type_resource.go
@@ -173,7 +173,7 @@ func (r *ResourceTypeResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
+	if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Resource type with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/resource_type_resource.go
+++ b/internal/provider/resource_type_resource.go
@@ -219,12 +219,6 @@ func (r *ResourceTypeResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Resource type with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to update resource type, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/runner_rule_data_source.go
+++ b/internal/provider/runner_rule_data_source.go
@@ -99,8 +99,8 @@ func (d *RunnerRuleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
-		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner rule with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner rule with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/runner_rule_data_source.go
+++ b/internal/provider/runner_rule_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 
 	"github.com/google/uuid"
@@ -95,6 +96,12 @@ func (d *RunnerRuleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	httpResp, err := d.cpClient.GetRunnerRuleInOrgWithResponse(ctx, d.orgId, uuid.MustParse(data.Id.ValueString()))
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read runner rule, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner rule with ID %s not found in org %s", data.Id.ValueString(), d.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/runner_rule_resource.go
+++ b/internal/provider/runner_rule_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 	"terraform-provider-humanitec-v2/internal/ref"
 
@@ -139,6 +140,12 @@ func (r *RunnerRuleResource) Read(ctx context.Context, req resource.ReadRequest,
 	httpResp, err := r.cpClient.GetRunnerRuleInOrgWithResponse(ctx, r.orgId, uuid.MustParse(data.Id.ValueString()))
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_PROVIDER_ERR, fmt.Sprintf("Unable to read runner rule, got error: %s", err))
+		return
+	}
+
+	if httpResp.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner rule with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/runner_rule_resource.go
+++ b/internal/provider/runner_rule_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
 	"terraform-provider-humanitec-v2/internal/ref"
@@ -143,7 +144,7 @@ func (r *RunnerRuleResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if httpResp.StatusCode() == 404 {
+	if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Runner rule with ID %s not found in org %s", data.Id.ValueString(), r.orgId))
 		resp.State.RemoveResource(ctx)
 		return


### PR DESCRIPTION
This PR goes over all our data sources and resources and implements consistent 404 handling:

1. On a 404 for a data source read, we add an error and return since a data source attempts to target a specific existing resource and if it doesn't exist we can't move on.
2. On a 404 for a resource read, we add a warning, and drop state from the state file so that it can plan a recreate and replacement of dependent resources.
3. On a 404 for a resource update, we keep the current behaviour: throw an error so that the read on the next attempt returns a real 404 again. We must _not_ remove the resource from state here because sometimes we get a 404 on update due to referenced or related resources not existing.
4. All resources have been handling 404 on delete correctly already.