### PR TITLE
docs: fix provider import

### DIFF
--- a/docs/resources/provider.md
+++ b/docs/resources/provider.md
@@ -47,5 +47,5 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import platform-orchestrator_provider.my_provider "aws:my-aws-provider"
+terraform import platform-orchestrator_provider.my_provider "aws.my-aws-provider"
 ```

--- a/examples/resources/platform-orchestrator_provider/import.sh
+++ b/examples/resources/platform-orchestrator_provider/import.sh
@@ -1,1 +1,1 @@
-terraform import platform-orchestrator_provider.my_provider "aws:my-aws-provider"
+terraform import platform-orchestrator_provider.my_provider "aws.my-aws-provider"


### PR DESCRIPTION
We use `.` as separator between provider type and id not `:`.