### PR TITLE
feat: support type=s3 + s3_configuration for state storage configuration

### DIFF
--- a/docs/data-sources/kubernetes_agent_runner.md
+++ b/docs/data-sources/kubernetes_agent_runner.md
@@ -29,7 +29,7 @@ data "platform-orchestrator_kubernetes_agent_runner" "agent_runner" {
 
 - `description` (String) Kubernetes Agent Runner description
 - `runner_configuration` (Attributes) The configuration of the Kubernetes Agent Runner (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 <a id="nestedatt--runner_configuration"></a>
 ### Nested Schema for `runner_configuration`
@@ -53,10 +53,14 @@ Read-Only:
 <a id="nestedatt--state_storage_configuration"></a>
 ### Nested Schema for `state_storage_configuration`
 
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+
 Read-Only:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner
+- `type` (String) The type of state storage configuration for the Runner
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -64,3 +68,12 @@ Read-Only:
 Read-Only:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Read-Only:
+
+- `bucket` (String) Name of the S3 Bucket
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this

--- a/docs/data-sources/kubernetes_agent_runner.md
+++ b/docs/data-sources/kubernetes_agent_runner.md
@@ -56,7 +56,7 @@ Read-Only:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 Read-Only:
 
@@ -70,8 +70,8 @@ Read-Only:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Read-Only:
 

--- a/docs/data-sources/kubernetes_eks_runner.md
+++ b/docs/data-sources/kubernetes_eks_runner.md
@@ -29,7 +29,7 @@ data "platform-orchestrator_kubernetes_eks_runner" "kubernetes_eks_runner" {
 
 - `description` (String) The description of the Kubernetes EKS Runner.
 - `runner_configuration` (Attributes) The configuration of the Kubernetes EKS cluster. (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 <a id="nestedatt--runner_configuration"></a>
 ### Nested Schema for `runner_configuration`
@@ -73,10 +73,14 @@ Read-Only:
 <a id="nestedatt--state_storage_configuration"></a>
 ### Nested Schema for `state_storage_configuration`
 
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+
 Read-Only:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner
+- `type` (String) The type of state storage configuration for the Runner
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -84,3 +88,12 @@ Read-Only:
 Read-Only:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Read-Only:
+
+- `bucket` (String) Name of the S3 Bucket
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this

--- a/docs/data-sources/kubernetes_eks_runner.md
+++ b/docs/data-sources/kubernetes_eks_runner.md
@@ -76,7 +76,7 @@ Read-Only:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 Read-Only:
 
@@ -90,8 +90,8 @@ Read-Only:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Read-Only:
 

--- a/docs/data-sources/kubernetes_gke_runner.md
+++ b/docs/data-sources/kubernetes_gke_runner.md
@@ -78,7 +78,7 @@ Read-Only:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 Read-Only:
 
@@ -92,8 +92,8 @@ Read-Only:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Read-Only:
 

--- a/docs/data-sources/kubernetes_gke_runner.md
+++ b/docs/data-sources/kubernetes_gke_runner.md
@@ -29,7 +29,7 @@ data "platform-orchestrator_kubernetes_gke_runner" "kubernetes_gke_runner" {
 
 - `description` (String) Kubernetes GKE Runner description
 - `runner_configuration` (Attributes) The configuration of the Kubernetes GKE cluster (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 <a id="nestedatt--runner_configuration"></a>
 ### Nested Schema for `runner_configuration`
@@ -75,10 +75,14 @@ Read-Only:
 <a id="nestedatt--state_storage_configuration"></a>
 ### Nested Schema for `state_storage_configuration`
 
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+
 Read-Only:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner
+- `type` (String) The type of state storage configuration for the Runner
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -86,3 +90,12 @@ Read-Only:
 Read-Only:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Read-Only:
+
+- `bucket` (String) Name of the S3 Bucket
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this

--- a/docs/data-sources/kubernetes_runner.md
+++ b/docs/data-sources/kubernetes_runner.md
@@ -85,7 +85,7 @@ Read-Only:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 Read-Only:
 
@@ -99,8 +99,8 @@ Read-Only:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Read-Only:
 

--- a/docs/data-sources/kubernetes_runner.md
+++ b/docs/data-sources/kubernetes_runner.md
@@ -29,7 +29,7 @@ data "platform-orchestrator_kubernetes_runner" "kubernetes_runner" {
 
 - `description` (String) Kubernetes Runner description
 - `runner_configuration` (Attributes) The configuration of the Kubernetes Runner cluster (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 <a id="nestedatt--runner_configuration"></a>
 ### Nested Schema for `runner_configuration`
@@ -82,10 +82,14 @@ Read-Only:
 <a id="nestedatt--state_storage_configuration"></a>
 ### Nested Schema for `state_storage_configuration`
 
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+
 Read-Only:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner
+- `type` (String) The type of state storage configuration for the Runner
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -93,3 +97,12 @@ Read-Only:
 Read-Only:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Read-Only:
+
+- `bucket` (String) Name of the S3 Bucket
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this

--- a/docs/resources/kubernetes_agent_runner.md
+++ b/docs/resources/kubernetes_agent_runner.md
@@ -88,7 +88,7 @@ Required:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -98,8 +98,8 @@ Required:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Required:
 

--- a/docs/resources/kubernetes_agent_runner.md
+++ b/docs/resources/kubernetes_agent_runner.md
@@ -50,7 +50,7 @@ EOT
 
 - `id` (String) The unique identifier for the Kubernetes Agent Runner.
 - `runner_configuration` (Attributes) The configuration of the Kubernetes Agent Runner. (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 ### Optional
 
@@ -83,8 +83,12 @@ Optional:
 
 Required:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner.
+- `type` (String) The type of state storage configuration for the Runner.
+
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -92,6 +96,18 @@ Required:
 Required:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Required:
+
+- `bucket` (String) Name of the S3 Bucket
+
+Optional:
+
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this
 
 ## Import
 

--- a/docs/resources/kubernetes_eks_runner.md
+++ b/docs/resources/kubernetes_eks_runner.md
@@ -115,7 +115,7 @@ Required:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -125,8 +125,8 @@ Required:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Required:
 

--- a/docs/resources/kubernetes_eks_runner.md
+++ b/docs/resources/kubernetes_eks_runner.md
@@ -54,7 +54,7 @@ resource "platform-orchestrator_kubernetes_eks_runner" "my_runner" {
 
 - `id` (String) The unique identifier for the Kubernetes EKS Runner.
 - `runner_configuration` (Attributes) The configuration of the Kubernetes EKS cluster. (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 ### Optional
 
@@ -110,8 +110,12 @@ Optional:
 
 Required:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner.
+- `type` (String) The type of state storage configuration for the Runner.
+
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -119,6 +123,18 @@ Required:
 Required:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Required:
+
+- `bucket` (String) Name of the S3 Bucket
+
+Optional:
+
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this
 
 ## Import
 

--- a/docs/resources/kubernetes_gke_runner.md
+++ b/docs/resources/kubernetes_gke_runner.md
@@ -55,7 +55,7 @@ resource "platform-orchestrator_kubernetes_gke_runner" "my_runner" {
 
 - `id` (String) The unique identifier for the Kubernetes GKE Runner.
 - `runner_configuration` (Attributes) The configuration of the Kubernetes GKE cluster. (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 ### Optional
 
@@ -113,8 +113,12 @@ Optional:
 
 Required:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner.
+- `type` (String) The type of state storage configuration for the Runner.
+
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -122,6 +126,18 @@ Required:
 Required:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Required:
+
+- `bucket` (String) Name of the S3 Bucket
+
+Optional:
+
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this
 
 ## Import
 

--- a/docs/resources/kubernetes_gke_runner.md
+++ b/docs/resources/kubernetes_gke_runner.md
@@ -118,7 +118,7 @@ Required:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -128,8 +128,8 @@ Required:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Required:
 

--- a/docs/resources/kubernetes_runner.md
+++ b/docs/resources/kubernetes_runner.md
@@ -124,7 +124,7 @@ Required:
 Optional:
 
 - `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
+- `s3_configuration` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3_configuration))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -134,8 +134,8 @@ Required:
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
 
 
-<a id="nestedatt--state_storage_configuration--s3"></a>
-### Nested Schema for `state_storage_configuration.s3`
+<a id="nestedatt--state_storage_configuration--s3_configuration"></a>
+### Nested Schema for `state_storage_configuration.s3_configuration`
 
 Required:
 

--- a/docs/resources/kubernetes_runner.md
+++ b/docs/resources/kubernetes_runner.md
@@ -54,7 +54,7 @@ resource "platform-orchestrator_kubernetes_runner" "my_runner" {
 
 - `id` (String) The unique identifier for the Kubernetes Runner.
 - `runner_configuration` (Attributes) The configuration of the Kubernetes Runner cluster. (see [below for nested schema](#nestedatt--runner_configuration))
-- `state_storage_configuration` (Attributes) The state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
+- `state_storage_configuration` (Attributes) The state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration))
 
 ### Optional
 
@@ -119,8 +119,12 @@ Optional:
 
 Required:
 
-- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Kubernetes Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
-- `type` (String) The type of state storage configuration for the Kubernetes Runner.
+- `type` (String) The type of state storage configuration for the Runner.
+
+Optional:
+
+- `kubernetes_configuration` (Attributes) The Kubernetes state storage configuration for the Runner. (see [below for nested schema](#nestedatt--state_storage_configuration--kubernetes_configuration))
+- `s3` (Attributes) The S3 state storage configuration for the Runner (see [below for nested schema](#nestedatt--state_storage_configuration--s3))
 
 <a id="nestedatt--state_storage_configuration--kubernetes_configuration"></a>
 ### Nested Schema for `state_storage_configuration.kubernetes_configuration`
@@ -128,6 +132,18 @@ Required:
 Required:
 
 - `namespace` (String) The namespace for the Kubernetes state storage configuration.
+
+
+<a id="nestedatt--state_storage_configuration--s3"></a>
+### Nested Schema for `state_storage_configuration.s3`
+
+Required:
+
+- `bucket` (String) Name of the S3 Bucket
+
+Optional:
+
+- `path_prefix` (String) A prefix path for the state file. The environment uuid will be used as a unique key within this
 
 ## Import
 

--- a/internal/clients/canyon-cp/spec.yaml
+++ b/internal/clients/canyon-cp/spec.yaml
@@ -492,6 +492,7 @@ paths:
         - $ref: "#/components/parameters/orgIdPathParam"
         - $ref: "#/components/parameters/projectIdPathParam"
         - $ref: "#/components/parameters/envIdPathParam"
+        - $ref: "#/components/parameters/forceQueryParam"
       responses:
         "202":
           description: The environment is waiting for a destroy deployment to succeed.
@@ -552,14 +553,15 @@ paths:
         "404":
           $ref: "#/components/responses/404NotFound"
 
-  /orgs/{orgId}/projects/{projectId}/envs/{envId}/actions/force_delete:
+  /internal/orgs/{orgId}/projects/{projectId}/envs/{envId}/actions/force-delete:
     post:
-      operationId: forceDeleteEnvironment
+      operationId: internalForceDeleteEnvironment
       summary: Force delete the environment without a successful destroy deployment.
       description: |
-        This is an escape hatch that may be used by privileged users to destroy an environment that cannot be fully destroyed or is facing errors that cannot be worked around. 
+        This is an escape hatch that may be used by privileged users to destroy an environment that cannot be fully destroyed or is facing errors that cannot be worked around.
         This may leave infrastructure or state behind that must be cleaned up manually outside of the Orchestrator.
       tags:
+        - internal
         - Environment
       security:
         - userIdHeader: []
@@ -1353,6 +1355,8 @@ paths:
                 $ref: "#/components/schemas/InternalModuleCatalogue"
         "404":
           $ref: "#/components/responses/404NotFound"
+        "409":
+          $ref: "#/components/responses/409Conflict"
 
 components:
   securitySchemes:
@@ -1482,6 +1486,14 @@ components:
       schema:
         type: boolean
         default: false
+    forceQueryParam:
+      name: force
+      in: query
+      description: If true, will perform force deletion, without destroying underlying infrastructure.
+      required: false
+      schema:
+        type: boolean
+        default: false
 
   responses:
     400BadRequest:
@@ -1591,17 +1603,23 @@ components:
     InternalOrganizationCreateBody:
       type: object
       description: A request to create a new organization state in the control plane.
-      required:
-        - id
       properties:
         id:
-          description: The unique identifier of the org
+          description: The unique identifier of the org. It will be auto-generated if not provided.
           type: string
           example: my-org123
           minLength: 5
           maxLength: 50
           pattern: ^[a-z](?:-?[a-z0-9]+)+$
           x-pattern-error: id must be lowercase alphanumeric including hyphens
+        id_prefix:
+          description: An id prefix for the org. If will be a prefix to the auto-generated id.
+          type: string
+          example: workshop-
+          minLength: 1
+          maxLength: 15
+          pattern: ^[a-z](?:-?[a-z0-9]+)+$
+          x-pattern-error: id_prefix must be lowercase alphanumeric including hyphens
 
     Project:
       type: object
@@ -1674,9 +1692,12 @@ components:
           x-pattern-error: id must be a valid identifier
         display_name:
           description: Project human readable name. The id is used if this is not specified.
+          minLength: 2
+          maxLength: 60
+          pattern: ^[^\p{Cc}\p{Cs}\p{Z}\n]( |[^\p{Cc}\p{Cs}\p{Z}\n])*[^\p{Cc}\p{Cs}\p{Z}\n]$
+          x-pattern-error: display_name contains invalid characters
           type: string
           example: Sample Project
-          maxLength: 60
 
     ProjectUpdateBody:
       type: object
@@ -1686,9 +1707,12 @@ components:
       properties:
         display_name:
           description: Project human readable name. The id is used if this is not specified.
+          minLength: 2
+          maxLength: 60
+          pattern: ^[^\p{Cc}\p{Cs}\p{Z}\n]( |[^\p{Cc}\p{Cs}\p{Z}\n])*[^\p{Cc}\p{Cs}\p{Z}\n]$
+          x-pattern-error: display_name contains invalid characters
           type: string
           example: Sample Project
-          maxLength: 60
 
     EnvironmentStatus:
       type: string
@@ -1791,9 +1815,12 @@ components:
           x-pattern-error: env_type_id must be a valid environment type identifier
         display_name:
           description: Environment human readable name. The id is used if this is not specified.
+          minLength: 2
+          maxLength: 60
+          pattern: ^[^\p{Cc}\p{Cs}\p{Z}\n]( |[^\p{Cc}\p{Cs}\p{Z}\n])*[^\p{Cc}\p{Cs}\p{Z}\n]$
+          x-pattern-error: display_name contains invalid characters
           type: string
           example: My Sample Environment
-          maxLength: 60
 
     EnvironmentUpdateBody:
       type: object
@@ -1803,9 +1830,12 @@ components:
       properties:
         display_name:
           description: Environment human readable name. The id is used if this is not specified.
+          minLength: 2
+          maxLength: 60
+          pattern: ^[^\p{Cc}\p{Cs}\p{Z}\n]( |[^\p{Cc}\p{Cs}\p{Z}\n])*[^\p{Cc}\p{Cs}\p{Z}\n]$
+          x-pattern-error: display_name contains invalid characters
           type: string
           example: My Sample Environment
-          maxLength: 60
 
     EnvironmentInternalUpdateBody:
       type: object
@@ -2254,7 +2284,7 @@ components:
       example: standard.common-postgres
       minLength: 1
       maxLength: 63
-      pattern: ^[a-z0-9]+(?:-+[a-z0-9]+)*(?:\\.[a-z0-9]+(?:-+[a-z0-9]+)*)*$
+      pattern: ^[a-z0-9]+(?:-+[a-z0-9]+)*(?:\.[a-z0-9]+(?:-+[a-z0-9]+)*)*$
       x-pattern-error: resource id must be a valid resource id with one or more dot-separated parts of lowercase alphanumerics and hyphens
 
     RunnerType:
@@ -2265,12 +2295,14 @@ components:
         - kubernetes-gke
         - kubernetes-agent
         - kubernetes-eks
+        - serverless-ecs
 
     StateStorageType:
       description: Type of the Terraform Backend used by the runner.
       type: string
       enum:
         - kubernetes
+        - s3
 
     ModuleSummary:
       type: object
@@ -2664,6 +2696,7 @@ components:
         - $ref: "#/components/schemas/K8sGkeRunnerConfiguration"
         - $ref: "#/components/schemas/K8sEksRunnerConfiguration"
         - $ref: "#/components/schemas/K8sAgentRunnerConfiguration"
+        - $ref: "#/components/schemas/ServerlessEcsRunnerConfiguration"
       discriminator:
         propertyName: type
         mapping:
@@ -2671,6 +2704,7 @@ components:
           kubernetes-gke: "#/components/schemas/K8sGkeRunnerConfiguration"
           kubernetes-eks: "#/components/schemas/K8sEksRunnerConfiguration"
           kubernetes-agent: "#/components/schemas/K8sAgentRunnerConfiguration"
+          serverless-ecs: "#/components/schemas/ServerlessEcsRunnerConfiguration"
 
     RunnerConfigurationUpdate:
       description: The data needed to update the runner configuration.
@@ -2679,6 +2713,7 @@ components:
         - $ref: "#/components/schemas/K8sGkeRunnerConfigurationUpdateBody"
         - $ref: "#/components/schemas/K8sEksRunnerConfigurationUpdateBody"
         - $ref: "#/components/schemas/K8sAgentRunnerConfigurationUpdateBody"
+        - $ref: "#/components/schemas/ServerlessEcsRunnerConfigurationUpdateBody"
       discriminator:
         propertyName: type
         mapping:
@@ -2686,6 +2721,7 @@ components:
           kubernetes-gke: "#/components/schemas/K8sGkeRunnerConfigurationUpdateBody"
           kubernetes-eks: "#/components/schemas/K8sEksRunnerConfigurationUpdateBody"
           kubernetes-agent: "#/components/schemas/K8sAgentRunnerConfigurationUpdateBody"
+          serverless-ecs: "#/components/schemas/ServerlessEcsRunnerConfigurationUpdateBody"
 
     InternalRunner:
       type: object
@@ -2786,15 +2822,14 @@ components:
           description: AWS region where the EKS cluster is located.
           type: string
         auth:
-          $ref: "#/components/schemas/K8sRunnerAwsTemporaryAuth"
+          $ref: "#/components/schemas/AwsTemporaryAuth"
       required:
         - name
         - region
         - auth
 
-    K8sRunnerAwsTemporaryAuth:
-      description: Configuration to obtain temporary access token to access an EKS cluster.
-      x-go-type-skip-optional-pointer: true
+    AwsTemporaryAuth:
+      description: Configuration to obtain temporary AWS security credentials by assuming an IAM role.
       type: object
       properties:
         role_arn:
@@ -2803,12 +2838,14 @@ components:
           pattern: ^arn:aws:iam::[0-9]{12}:role\/[a-zA-Z_0-9+=,.@\-_/]+$
           x-pattern-error: role_arn is not a valid IAM Role ARN
         session_name:
-          description: Optional session name to be used when assuming the role.
+          description: (Optional) Session name to be used when assuming the role. If not provided, a default session name will be "{org_id}-{runner_id}".
           type: string
+          pattern: ^[a-zA-Z0-9+=,.@\-_/]+$
           minLength: 3
           maxLength: 64
+          x-pattern-error: session_name must contain only valid characters (letters, digits, and +=,.@-_/)
         sts_region:
-          description: Optional AWS STS region to use instead of the global endpoint.
+          description: (Optional) The AWS region identifier for the Security Token Service (STS) endpoint. If not provided, the cluster region will be used.
           type: string
           pattern: ^[a-z]{2}-[a-z]+-\d$
           x-pattern-error: sts_region is not a valid AWS STS region
@@ -2876,10 +2913,12 @@ components:
       description: Configuration for the Terraform Backend used by the runner.
       oneOf:
         - $ref: "#/components/schemas/K8sStorageConfiguration"
+        - $ref: "#/components/schemas/S3StorageConfiguration"
       discriminator:
         propertyName: type
         mapping:
           kubernetes: "#/components/schemas/K8sStorageConfiguration"
+          s3: "#/components/schemas/S3StorageConfiguration"
 
     StateStorageConfigurationSummary:
       description: Summary of the state storage configuration.
@@ -2901,6 +2940,31 @@ components:
       required:
         - namespace
         - type
+
+    S3StorageConfiguration:
+      description: |-
+        Configuration to use an AWS S3 bucket as state storage backend of this runner. Authentication and other settings
+        can be set via environment variables and defaults. See <https://developer.hashicorp.com/terraform/language/backend/s3#state-storage>
+        for more details.
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/StateStorageType"
+        bucket:
+          type: string
+          description: Name of the S3 Bucket.
+          pattern: ^[a-z0-9][a-z0-9\-]*[a-z0-9]$
+          x-pattern-error: state storage bucket is not a valid S3 Bucket name.
+          example: example-bucket
+        path_prefix:
+          type: string
+          description: A prefix path for the state file. The environment uuid will be used as a unique key within this.
+          pattern: ^[a-zA-Z0-9._-]+(?:\/[a-zA-Z0-9._-]+)*\/?$
+          x-pattern-error: state storage path_prefix is not a valid S3 prefix path.
+          example: path/to/state/directory
+      required:
+        - type
+        - bucket
 
     RunnerCreateBody:
       type: object
@@ -2994,6 +3058,101 @@ components:
         - job
         - key
 
+    ServerlessEcsRunnerConfiguration:
+      description: Runner configuration for executing on AWS ECS Fargate.
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/RunnerType"
+        auth:
+          $ref: "#/components/schemas/AwsTemporaryAuth"
+        job:
+          $ref: "#/components/schemas/ServerlessEcsRunnerJob"
+      required:
+        - type
+        - auth
+        - job
+
+    ServerlessEcsRunnerJob:
+      description: Job details for the AWS ECS Runner
+      required:
+        - region
+        - cluster
+        - subnets
+        - execution_role_arn
+      properties:
+        region:
+          description: AWS Region to run the ECS job in.
+          type: string
+          pattern: ^[a-z]{2}-[a-z]+-\d$
+          x-pattern-error: job region is not a valid AWS Region.
+          example: us-west-2
+          minLength: 1
+          maxLength: 24
+        cluster:
+          description: ECS Fargate cluster name
+          type: string
+          example: my-cluster
+          minLength: 1
+          maxLength: 255
+        subnets:
+          description: The IDs of the AWS subnets that the runner must be connected to. At least one is required.
+          type: array
+          items:
+            type: string
+            example: "subnet-12345"
+            minLength: 1
+            maxLength: 24
+          minItems: 1
+          maxItems: 16
+        security_groups:
+          description: An optional list of IDs for the AWS security groups that the runner should be associated with.
+          type: array
+          items:
+            type: string
+            example: "runner-security-group"
+            minLength: 1
+            maxLength: 255
+          maxItems: 5
+          x-go-type-skip-optional-pointer: true
+        is_public_ip_enabled:
+          description: |
+            Whether to assign a public ip to the ECS task. This is required if the target subnets use Internet Gateways 
+            instead of NAT Gateways to reach public networks. Defaults to false.
+          type: boolean
+          example: true
+          x-go-type-skip-optional-pointer: true
+        execution_role_arn:
+          description: The ARN of the role used to pull images, retrieve secrets and parameters, and execute the Runner.
+          type: string
+          pattern: ^arn:aws:iam::\d{12}:role\/[a-zA-Z_0-9+=,.@\-_/]+$
+          x-pattern-error: job execution_role_arn is not a valid IAM Role ARN
+          example: arn:aws:iam::123456789012:role/ECSExecutionRole
+        task_role_arn:
+          description: An optional ARN for the role available inside the Runner.
+          type: string
+          pattern: ^arn:aws:iam::\d{12}:role\/[a-zA-Z_0-9+=,.@\-_/]+$
+          x-pattern-error: job task_role_arn is not a valid IAM Role ARN
+          example: arn:aws:iam::123456789012:role/ECSTaskRole
+        environment:
+          description: Additional environment variables to pass to the ECS job.
+          type: object
+          x-go-type-skip-optional-pointer: true
+          additionalProperties:
+            description: The value of the variable.
+            type: string
+            maxLength: 1024
+        secrets:
+          description: A set of AWS Secrets Manager Secrets or Parameter Store Parameters to mount
+          type: object
+          x-go-type-skip-optional-pointer: true
+          additionalProperties:
+            description: The source ARN
+            type: string
+            pattern: ^arn:aws:((secretsmanager:[^:]+:[^:]+:secret:[^:]+-[a-zA-Z0-9]{6})|(ssm:[^:]+:[^:]+:parameter\/.+))$
+            x-pattern-error: job secrets value is not a valid AWS Secret or Parameter ARN
+            example: arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/database/credentials-AbCdEf
+
     RunnerUpdateBody:
       type: object
       description: A request to update a runner
@@ -3056,6 +3215,19 @@ components:
           $ref: "#/components/schemas/RunnerType"
         key:
           $ref: "#/components/schemas/K8sAgentRunnerKey"
+      required:
+        - type
+
+    ServerlessEcsRunnerConfigurationUpdateBody:
+      description: Runner configuration for executing on AWS ECS Fargate.
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/RunnerType"
+        auth:
+          $ref: "#/components/schemas/AwsTemporaryAuth"
+        job:
+          $ref: "#/components/schemas/ServerlessEcsRunnerJob"
       required:
         - type
 

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -270,7 +270,7 @@ func (r *EnvironmentResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	if httpResp, err := r.cpClient.DeleteEnvironmentWithResponse(ctx, r.orgId, data.ProjectId.ValueString(), data.Id.ValueString()); err != nil {
+	if httpResp, err := r.cpClient.DeleteEnvironmentWithResponse(ctx, r.orgId, data.ProjectId.ValueString(), data.Id.ValueString(), &canyoncp.DeleteEnvironmentParams{}); err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to delete environment, got error: %s", err))
 	} else if httpResp.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddWarning(HUM_RESOURCE_NOT_FOUND_ERR, fmt.Sprintf("Environment with ID %s no longer found in project %s", data.Id.ValueString(), data.ProjectId.ValueString()))

--- a/internal/provider/kubernetes_agent_runner_resource.go
+++ b/internal/provider/kubernetes_agent_runner_resource.go
@@ -143,8 +143,7 @@ func toKubernetesAgentRunnerResourceModel(item canyoncp.Runner, _ commonRunnerMo
 		return commonRunnerModel{}, err
 	}
 
-	k8sStateStorageConfiguration, _ := item.StateStorageConfiguration.AsK8sStorageConfiguration()
-	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), item.StateStorageConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}

--- a/internal/provider/kubernetes_agent_runner_resource.go
+++ b/internal/provider/kubernetes_agent_runner_resource.go
@@ -138,13 +138,12 @@ func parseKubernetesAgentRunnerConfigurationResponse(ctx context.Context, k8sAge
 
 func toKubernetesAgentRunnerResourceModel(item canyoncp.Runner, _ commonRunnerModel) (commonRunnerModel, error) {
 	k8sAgentRunnerConfiguration, _ := item.RunnerConfiguration.AsK8sAgentRunnerConfiguration()
-	k8sStateStorageConfiguration, _ := item.StateStorageConfiguration.AsK8sStorageConfiguration()
-
 	runnerConfigurationModel, err := parseKubernetesAgentRunnerConfigurationResponse(context.Background(), k8sAgentRunnerConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}
 
+	k8sStateStorageConfiguration, _ := item.StateStorageConfiguration.AsK8sStorageConfiguration()
 	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err

--- a/internal/provider/kubernetes_agent_runner_resource.go
+++ b/internal/provider/kubernetes_agent_runner_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -146,9 +145,9 @@ func toKubernetesAgentRunnerResourceModel(item canyoncp.Runner, _ commonRunnerMo
 		return commonRunnerModel{}, err
 	}
 
-	stateStorageConfigurationModel := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
-	if stateStorageConfigurationModel == nil {
-		return commonRunnerModel{}, errors.New("failed to parse state storage configuration")
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	if err != nil {
+		return commonRunnerModel{}, err
 	}
 
 	return commonRunnerModel{

--- a/internal/provider/kubernetes_agent_runner_resource_test.go
+++ b/internal/provider/kubernetes_agent_runner_resource_test.go
@@ -56,7 +56,7 @@ MCowBQYDK2VwAyEAc5dgCx4ano39JT0XgTsHnts3jej+5xl7ZAwSIrKpef0=
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},
@@ -95,7 +95,7 @@ MCowBQYDK2VwAyEAc5dgCx4ano39JT0XgTsHnts3jej+5xl7ZAwSIrKpeg0=
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("default"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},
@@ -207,7 +207,7 @@ EOT
 						tfjsonpath.New("state_storage_configuration"),
 						knownvalue.MapExact(map[string]knownvalue.Check{
 							"type": knownvalue.StringExact("s3"),
-							"s3": knownvalue.MapExact(map[string]knownvalue.Check{
+							"s3_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"bucket":      knownvalue.StringExact("some-bucket"),
 								"path_prefix": knownvalue.StringExact("some/prefix"),
 							}),

--- a/internal/provider/kubernetes_agent_runner_resource_test.go
+++ b/internal/provider/kubernetes_agent_runner_resource_test.go
@@ -56,6 +56,7 @@ MCowBQYDK2VwAyEAc5dgCx4ano39JT0XgTsHnts3jej+5xl7ZAwSIrKpef0=
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},
@@ -94,6 +95,7 @@ MCowBQYDK2VwAyEAc5dgCx4ano39JT0XgTsHnts3jej+5xl7ZAwSIrKpeg0=
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("default"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/kubernetes_agent_runner_resource_test.go
+++ b/internal/provider/kubernetes_agent_runner_resource_test.go
@@ -163,3 +163,65 @@ EOT
 }
 `
 }
+
+func TestAccKubernetesAgentRunnerResource_s3_state(t *testing.T) {
+	var runnerId = fmt.Sprint("runner-", time.Now().UnixNano())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: `
+resource "platform-orchestrator_kubernetes_agent_runner" "test" {
+  id = "` + runnerId + `"
+  runner_configuration = {
+	key = <<EOT
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAc5dgCx4ano39JT0XgTsHnts3jej+5xl7ZAwSIrKpeg0=
+-----END PUBLIC KEY-----
+EOT
+	job = {
+	  namespace = "default"
+      service_account = "humanitec-runner"
+	  pod_template = "{}"
+	}
+  }
+  state_storage_configuration = {
+	type = "s3"
+	s3_configuration = {
+	  bucket = "some-bucket"
+      path_prefix = "some/prefix"
+	}
+  }
+}
+`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"platform-orchestrator_kubernetes_agent_runner.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringExact(runnerId),
+					),
+					statecheck.ExpectKnownValue(
+						"platform-orchestrator_kubernetes_agent_runner.test",
+						tfjsonpath.New("state_storage_configuration"),
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"type": knownvalue.StringExact("s3"),
+							"s3": knownvalue.MapExact(map[string]knownvalue.Check{
+								"bucket":      knownvalue.StringExact("some-bucket"),
+								"path_prefix": knownvalue.StringExact("some/prefix"),
+							}),
+							"kubernetes_configuration": knownvalue.Null(),
+						}),
+					),
+				},
+			},
+			{
+				ResourceName:      "platform-orchestrator_kubernetes_agent_runner.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/internal/provider/kubernetes_eks_runner_resource.go
+++ b/internal/provider/kubernetes_eks_runner_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -228,9 +227,9 @@ func toKubernetesEksRunnerResourceModel(item canyoncp.Runner, _ commonRunnerMode
 		return commonRunnerModel{}, err
 	}
 
-	stateStorageConfigurationModel := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
-	if stateStorageConfigurationModel == nil {
-		return commonRunnerModel{}, errors.New("failed to parse state storage configuration")
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	if err != nil {
+		return commonRunnerModel{}, err
 	}
 
 	return commonRunnerModel{

--- a/internal/provider/kubernetes_eks_runner_resource.go
+++ b/internal/provider/kubernetes_eks_runner_resource.go
@@ -260,7 +260,7 @@ func createKubernetesEksRunnerConfigurationFromObject(ctx context.Context, obj t
 		Cluster: canyoncp.K8sRunnerEksCluster{
 			Name:   runnerConfig.Cluster.Name.ValueString(),
 			Region: runnerConfig.Cluster.Region.ValueString(),
-			Auth: canyoncp.K8sRunnerAwsTemporaryAuth{
+			Auth: canyoncp.AwsTemporaryAuth{
 				RoleArn:     runnerConfig.Cluster.Auth.RoleArn.ValueString(),
 				SessionName: fromStringValueToStringPointer(runnerConfig.Cluster.Auth.SessionName),
 				StsRegion:   fromStringValueToStringPointer(runnerConfig.Cluster.Auth.StsRegion),
@@ -294,7 +294,7 @@ func updateKubernetesEksRunnerConfigurationFromObject(ctx context.Context, obj t
 		Cluster: &canyoncp.K8sRunnerEksCluster{
 			Name:   runnerConfig.Cluster.Name.ValueString(),
 			Region: runnerConfig.Cluster.Region.ValueString(),
-			Auth: canyoncp.K8sRunnerAwsTemporaryAuth{
+			Auth: canyoncp.AwsTemporaryAuth{
 				RoleArn:     runnerConfig.Cluster.Auth.RoleArn.ValueString(),
 				SessionName: fromStringValueToStringPointer(runnerConfig.Cluster.Auth.SessionName),
 				StsRegion:   fromStringValueToStringPointer(runnerConfig.Cluster.Auth.StsRegion),

--- a/internal/provider/kubernetes_eks_runner_resource.go
+++ b/internal/provider/kubernetes_eks_runner_resource.go
@@ -220,14 +220,13 @@ func parseKubernetesEksRunnerConfigurationResponse(ctx context.Context, k8sEksRu
 
 func toKubernetesEksRunnerResourceModel(item canyoncp.Runner, _ commonRunnerModel) (commonRunnerModel, error) {
 	k8sRunnerConfiguration, _ := item.RunnerConfiguration.AsK8sEksRunnerConfiguration()
-	k8sStateStorageConfiguration, _ := item.StateStorageConfiguration.AsK8sStorageConfiguration()
 
 	runnerConfigurationModel, err := parseKubernetesEksRunnerConfigurationResponse(context.Background(), k8sRunnerConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}
 
-	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), item.StateStorageConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}

--- a/internal/provider/kubernetes_eks_runner_resource_test.go
+++ b/internal/provider/kubernetes_eks_runner_resource_test.go
@@ -54,7 +54,7 @@ func TestAccKubernetesEksRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},
@@ -96,7 +96,7 @@ func TestAccKubernetesEksRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("default"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/kubernetes_eks_runner_resource_test.go
+++ b/internal/provider/kubernetes_eks_runner_resource_test.go
@@ -54,6 +54,7 @@ func TestAccKubernetesEksRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},
@@ -95,6 +96,7 @@ func TestAccKubernetesEksRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("default"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/kubernetes_gke_runner_resource.go
+++ b/internal/provider/kubernetes_gke_runner_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -226,9 +225,9 @@ func toKubernetesGkeRunnerResourceModel(item canyoncp.Runner, _ commonRunnerMode
 		return commonRunnerModel{}, err
 	}
 
-	stateStorageConfigurationModel := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
-	if stateStorageConfigurationModel == nil {
-		return commonRunnerModel{}, errors.New("failed to parse state storage configuration")
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	if err != nil {
+		return commonRunnerModel{}, err
 	}
 
 	return commonRunnerModel{

--- a/internal/provider/kubernetes_gke_runner_resource.go
+++ b/internal/provider/kubernetes_gke_runner_resource.go
@@ -218,14 +218,13 @@ func parseKubernetesGKERunnerConfigurationResponse(ctx context.Context, k8sGKERu
 
 func toKubernetesGkeRunnerResourceModel(item canyoncp.Runner, _ commonRunnerModel) (commonRunnerModel, error) {
 	k8sRunnerConfiguration, _ := item.RunnerConfiguration.AsK8sGkeRunnerConfiguration()
-	k8sStateStorageConfiguration, _ := item.StateStorageConfiguration.AsK8sStorageConfiguration()
 
 	runnerConfigurationModel, err := parseKubernetesGKERunnerConfigurationResponse(context.Background(), k8sRunnerConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}
 
-	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), item.StateStorageConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}

--- a/internal/provider/kubernetes_gke_runner_resource_test.go
+++ b/internal/provider/kubernetes_gke_runner_resource_test.go
@@ -56,7 +56,7 @@ func TestAccKubernetesGkeRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},
@@ -100,7 +100,7 @@ func TestAccKubernetesGkeRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("default"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/kubernetes_gke_runner_resource_test.go
+++ b/internal/provider/kubernetes_gke_runner_resource_test.go
@@ -56,6 +56,7 @@ func TestAccKubernetesGkeRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},
@@ -99,6 +100,7 @@ func TestAccKubernetesGkeRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("default"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/kubernetes_runner_resource.go
+++ b/internal/provider/kubernetes_runner_resource.go
@@ -251,14 +251,13 @@ func parseKubernetesRunnerConfigurationResponse(ctx context.Context, k8sRunnerCo
 
 func toKubernetesRunnerResourceModel(item canyoncp.Runner, data commonRunnerModel) (commonRunnerModel, error) {
 	k8sRunnerConfiguration, _ := item.RunnerConfiguration.AsK8sRunnerConfiguration()
-	k8sStateStorageConfiguration, _ := item.StateStorageConfiguration.AsK8sStorageConfiguration()
 
 	runnerConfigurationModel, err := parseKubernetesRunnerConfigurationResponse(context.Background(), k8sRunnerConfiguration, &data)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}
 
-	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), item.StateStorageConfiguration)
 	if err != nil {
 		return commonRunnerModel{}, err
 	}

--- a/internal/provider/kubernetes_runner_resource.go
+++ b/internal/provider/kubernetes_runner_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -259,9 +258,9 @@ func toKubernetesRunnerResourceModel(item canyoncp.Runner, data commonRunnerMode
 		return commonRunnerModel{}, err
 	}
 
-	stateStorageConfigurationModel := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
-	if stateStorageConfigurationModel == nil {
-		return commonRunnerModel{}, errors.New("failed to parse state storage configuration")
+	stateStorageConfigurationModel, err := parseStateStorageConfigurationResponse(context.Background(), k8sStateStorageConfiguration)
+	if err != nil {
+		return commonRunnerModel{}, err
 	}
 
 	return commonRunnerModel{

--- a/internal/provider/kubernetes_runner_resource_test.go
+++ b/internal/provider/kubernetes_runner_resource_test.go
@@ -64,6 +64,7 @@ func TestAccKubernetesRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},
@@ -133,6 +134,7 @@ service_account_token = "service-account-token"
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/kubernetes_runner_resource_test.go
+++ b/internal/provider/kubernetes_runner_resource_test.go
@@ -187,6 +187,7 @@ service_account_token = "another-service-account-token"
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
+							"s3": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/kubernetes_runner_resource_test.go
+++ b/internal/provider/kubernetes_runner_resource_test.go
@@ -64,7 +64,7 @@ func TestAccKubernetesRunnerResource(t *testing.T) {
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},
@@ -134,7 +134,7 @@ service_account_token = "service-account-token"
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},
@@ -187,7 +187,7 @@ service_account_token = "another-service-account-token"
 							"kubernetes_configuration": knownvalue.MapExact(map[string]knownvalue.Check{
 								"namespace": knownvalue.StringExact("humanitec-runner"),
 							}),
-							"s3": knownvalue.Null(),
+							"s3_configuration": knownvalue.Null(),
 						}),
 					),
 				},

--- a/internal/provider/runner_common_data_source.go
+++ b/internal/provider/runner_common_data_source.go
@@ -33,12 +33,18 @@ type commonRunnerModel struct {
 }
 
 type commonRunnerStateStorageModel struct {
-	Type                    string                                  `tfsdk:"type"`
-	KubernetesConfiguration commonRunnerKubernetesStateStorageModel `tfsdk:"kubernetes_configuration"`
+	Type                    string                                   `tfsdk:"type"`
+	KubernetesConfiguration *commonRunnerKubernetesStateStorageModel `tfsdk:"kubernetes_configuration"`
+	S3                      *commonRunnerS3StateStorageModel         `tfsdk:"s3"`
 }
 
 type commonRunnerKubernetesStateStorageModel struct {
 	Namespace string `tfsdk:"namespace"`
+}
+
+type commonRunnerS3StateStorageModel struct {
+	Bucket     string `tfsdk:"bucket"`
+	PathPrefix string `tfsdk:"path_prefix"`
 }
 
 func (d *commonRunnerDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -46,19 +52,35 @@ func (d *commonRunnerDataSource) Metadata(ctx context.Context, req datasource.Me
 }
 
 var commonRunnerStateStorageDataSourceSchema = schema.SingleNestedAttribute{
-	MarkdownDescription: "The state storage configuration for the Kubernetes Runner",
+	MarkdownDescription: "The state storage configuration for the Runner",
 	Computed:            true,
 	Attributes: map[string]schema.Attribute{
 		"type": schema.StringAttribute{
-			MarkdownDescription: "The type of state storage configuration for the Kubernetes Runner",
+			MarkdownDescription: "The type of state storage configuration for the Runner",
 			Computed:            true,
 		},
 		"kubernetes_configuration": schema.SingleNestedAttribute{
-			MarkdownDescription: "The Kubernetes state storage configuration for the Kubernetes Runner",
+			MarkdownDescription: "The Kubernetes state storage configuration for the Runner",
+			Optional:            true,
 			Computed:            true,
 			Attributes: map[string]schema.Attribute{
 				"namespace": schema.StringAttribute{
 					MarkdownDescription: "The namespace for the Kubernetes state storage configuration",
+					Computed:            true,
+				},
+			},
+		},
+		"s3": schema.SingleNestedAttribute{
+			MarkdownDescription: "The S3 state storage configuration for the Runner",
+			Optional:            true,
+			Computed:            true,
+			Attributes: map[string]schema.Attribute{
+				"bucket": schema.StringAttribute{
+					MarkdownDescription: "Name of the S3 Bucket",
+					Computed:            true,
+				},
+				"path_prefix": schema.StringAttribute{
+					MarkdownDescription: "A prefix path for the state file. The environment uuid will be used as a unique key within this",
 					Computed:            true,
 				},
 			},

--- a/internal/provider/runner_common_data_source.go
+++ b/internal/provider/runner_common_data_source.go
@@ -43,8 +43,8 @@ type commonRunnerKubernetesStateStorageModel struct {
 }
 
 type commonRunnerS3StateStorageModel struct {
-	Bucket     string `tfsdk:"bucket"`
-	PathPrefix string `tfsdk:"path_prefix"`
+	Bucket     string  `tfsdk:"bucket"`
+	PathPrefix *string `tfsdk:"path_prefix"`
 }
 
 func (d *commonRunnerDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/runner_common_data_source.go
+++ b/internal/provider/runner_common_data_source.go
@@ -35,7 +35,7 @@ type commonRunnerModel struct {
 type commonRunnerStateStorageModel struct {
 	Type                    string                                   `tfsdk:"type"`
 	KubernetesConfiguration *commonRunnerKubernetesStateStorageModel `tfsdk:"kubernetes_configuration"`
-	S3                      *commonRunnerS3StateStorageModel         `tfsdk:"s3"`
+	S3Configuration         *commonRunnerS3StateStorageModel         `tfsdk:"s3_configuration"`
 }
 
 type commonRunnerKubernetesStateStorageModel struct {
@@ -70,7 +70,7 @@ var commonRunnerStateStorageDataSourceSchema = schema.SingleNestedAttribute{
 				},
 			},
 		},
-		"s3": schema.SingleNestedAttribute{
+		"s3_configuration": schema.SingleNestedAttribute{
 			MarkdownDescription: "The S3 state storage configuration for the Runner",
 			Optional:            true,
 			Computed:            true,

--- a/internal/provider/runner_common_resource.go
+++ b/internal/provider/runner_common_resource.go
@@ -36,19 +36,19 @@ func (r *commonRunnerResource) Metadata(ctx context.Context, req resource.Metada
 }
 
 var commonRunnerStateStorageResourceSchema = schema.SingleNestedAttribute{
-	MarkdownDescription: "The state storage configuration for the Kubernetes Runner.",
+	MarkdownDescription: "The state storage configuration for the Runner.",
 	Required:            true,
 	Attributes: map[string]schema.Attribute{
 		"type": schema.StringAttribute{
-			MarkdownDescription: "The type of state storage configuration for the Kubernetes Runner.",
+			MarkdownDescription: "The type of state storage configuration for the Runner.",
 			Required:            true,
 			Validators: []validator.String{
-				stringvalidator.OneOf("kubernetes"),
+				stringvalidator.OneOf("kubernetes", "s3"),
 			},
 		},
 		"kubernetes_configuration": schema.SingleNestedAttribute{
-			MarkdownDescription: "The Kubernetes state storage configuration for the Kubernetes Runner.",
-			Required:            true,
+			MarkdownDescription: "The Kubernetes state storage configuration for the Runner.",
+			Optional:            true,
 			Attributes: map[string]schema.Attribute{
 				"namespace": schema.StringAttribute{
 					MarkdownDescription: "The namespace for the Kubernetes state storage configuration.",
@@ -56,6 +56,20 @@ var commonRunnerStateStorageResourceSchema = schema.SingleNestedAttribute{
 					Validators: []validator.String{
 						stringvalidator.LengthAtMost(63),
 					},
+				},
+			},
+		},
+		"s3": schema.SingleNestedAttribute{
+			MarkdownDescription: "The S3 state storage configuration for the Runner",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"bucket": schema.StringAttribute{
+					MarkdownDescription: "Name of the S3 Bucket",
+					Required:            true,
+				},
+				"path_prefix": schema.StringAttribute{
+					MarkdownDescription: "A prefix path for the state file. The environment uuid will be used as a unique key within this",
+					Optional:            true,
 				},
 			},
 		},

--- a/internal/provider/runner_common_resource.go
+++ b/internal/provider/runner_common_resource.go
@@ -43,7 +43,7 @@ var commonRunnerStateStorageResourceSchema = schema.SingleNestedAttribute{
 			MarkdownDescription: "The type of state storage configuration for the Runner.",
 			Required:            true,
 			Validators: []validator.String{
-				stringvalidator.OneOf("kubernetes", "s3"),
+				stringvalidator.OneOf(string(canyoncp.StateStorageTypeKubernetes), string(canyoncp.StateStorageTypeS3)),
 			},
 		},
 		"kubernetes_configuration": schema.SingleNestedAttribute{
@@ -59,7 +59,7 @@ var commonRunnerStateStorageResourceSchema = schema.SingleNestedAttribute{
 				},
 			},
 		},
-		"s3": schema.SingleNestedAttribute{
+		"s3_configuration": schema.SingleNestedAttribute{
 			MarkdownDescription: "The S3 state storage configuration for the Runner",
 			Optional:            true,
 			Attributes: map[string]schema.Attribute{

--- a/internal/provider/runner_helpers.go
+++ b/internal/provider/runner_helpers.go
@@ -4,31 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-
-	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
-	"terraform-provider-humanitec-v2/internal/ref"
-
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-)
 
-func commonStateStorageConfigurationAttributes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"type": types.StringType,
-		"kubernetes_configuration": types.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"namespace": types.StringType,
-			},
-		},
-		"s3_configuration": types.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"bucket":      types.StringType,
-				"path_prefix": types.StringType,
-			},
-		},
-	}
-}
+	canyoncp "terraform-provider-humanitec-v2/internal/clients/canyon-cp"
+)
 
 func parseStateStorageConfigurationResponse(ctx context.Context, ssc canyoncp.StateStorageConfiguration) (*basetypes.ObjectValue, error) {
 	var stateStorageConfig commonRunnerStateStorageModel
@@ -39,7 +19,7 @@ func parseStateStorageConfigurationResponse(ctx context.Context, ssc canyoncp.St
 		typedSsc, _ := ssc.AsS3StorageConfiguration()
 		stateStorageConfig.S3Configuration = &commonRunnerS3StateStorageModel{
 			Bucket:     typedSsc.Bucket,
-			PathPrefix: ref.DerefOr(typedSsc.PathPrefix, ""),
+			PathPrefix: typedSsc.PathPrefix,
 		}
 	case canyoncp.StateStorageTypeKubernetes:
 		typedSsc, _ := ssc.AsK8sStorageConfiguration()
@@ -50,7 +30,12 @@ func parseStateStorageConfigurationResponse(ctx context.Context, ssc canyoncp.St
 		return nil, fmt.Errorf("unsupported state storage type: %s", stateStorageConfig.Type)
 	}
 
-	objectValue, diags := types.ObjectValueFrom(ctx, commonStateStorageConfigurationAttributes(), stateStorageConfig)
+	attrs, err := AttributeTypesFromResourceSchema(commonRunnerStateStorageResourceSchema.Attributes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build attributes: %v", err)
+	}
+
+	objectValue, diags := types.ObjectValueFrom(ctx, attrs, stateStorageConfig)
 	if diags.HasError() {
 		return nil, fmt.Errorf("failed to build state storage configuration from model parsing API response: %v", diags.Errors())
 	}
@@ -67,12 +52,18 @@ func createStateStorageConfigurationFromObject(ctx context.Context, obj types.Ob
 	var stateStorageConfiguration = new(canyoncp.StateStorageConfiguration)
 	switch canyoncp.StateStorageType(stateStorageConfig.Type) {
 	case canyoncp.StateStorageTypeS3:
+		if stateStorageConfig.S3Configuration == nil {
+			return canyoncp.StateStorageConfiguration{}, fmt.Errorf("s3 configuration in object is not set")
+		}
 		_ = stateStorageConfiguration.FromS3StorageConfiguration(canyoncp.S3StorageConfiguration{
 			Type:       canyoncp.StateStorageTypeS3,
 			Bucket:     stateStorageConfig.S3Configuration.Bucket,
-			PathPrefix: ref.RefStringEmptyNil(stateStorageConfig.S3Configuration.PathPrefix),
+			PathPrefix: stateStorageConfig.S3Configuration.PathPrefix,
 		})
 	case canyoncp.StateStorageTypeKubernetes:
+		if stateStorageConfig.KubernetesConfiguration == nil {
+			return canyoncp.StateStorageConfiguration{}, fmt.Errorf("k8s configuration in object is not set")
+		}
 		_ = stateStorageConfiguration.FromK8sStorageConfiguration(canyoncp.K8sStorageConfiguration{
 			Type:      canyoncp.StateStorageTypeKubernetes,
 			Namespace: stateStorageConfig.KubernetesConfiguration.Namespace,

--- a/internal/provider/runner_helpers.go
+++ b/internal/provider/runner_helpers.go
@@ -21,7 +21,7 @@ func commonStateStorageConfigurationAttributes() map[string]attr.Type {
 				"namespace": types.StringType,
 			},
 		},
-		"s3": types.ObjectType{
+		"s3_configuration": types.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"bucket":      types.StringType,
 				"path_prefix": types.StringType,
@@ -37,7 +37,7 @@ func parseStateStorageConfigurationResponse(ctx context.Context, ssc canyoncp.St
 	switch canyoncp.StateStorageType(stateStorageConfig.Type) {
 	case canyoncp.StateStorageTypeS3:
 		typedSsc, _ := ssc.AsS3StorageConfiguration()
-		stateStorageConfig.S3 = &commonRunnerS3StateStorageModel{
+		stateStorageConfig.S3Configuration = &commonRunnerS3StateStorageModel{
 			Bucket:     typedSsc.Bucket,
 			PathPrefix: ref.DerefOr(typedSsc.PathPrefix, ""),
 		}
@@ -69,8 +69,8 @@ func createStateStorageConfigurationFromObject(ctx context.Context, obj types.Ob
 	case canyoncp.StateStorageTypeS3:
 		_ = stateStorageConfiguration.FromS3StorageConfiguration(canyoncp.S3StorageConfiguration{
 			Type:       canyoncp.StateStorageTypeS3,
-			Bucket:     stateStorageConfig.S3.Bucket,
-			PathPrefix: ref.RefStringEmptyNil(stateStorageConfig.S3.PathPrefix),
+			Bucket:     stateStorageConfig.S3Configuration.Bucket,
+			PathPrefix: ref.RefStringEmptyNil(stateStorageConfig.S3Configuration.PathPrefix),
 		})
 	case canyoncp.StateStorageTypeKubernetes:
 		_ = stateStorageConfiguration.FromK8sStorageConfiguration(canyoncp.K8sStorageConfiguration{

--- a/internal/provider/runner_helpers.go
+++ b/internal/provider/runner_helpers.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func commonStateStorageConfigurationAttributes() map[string]attr.Type {
@@ -24,7 +23,7 @@ func commonStateStorageConfigurationAttributes() map[string]attr.Type {
 	}
 }
 
-func parseStateStorageConfigurationResponse(ctx context.Context, k8sStateStorageConfiguration canyoncp.K8sStorageConfiguration) *basetypes.ObjectValue {
+func parseStateStorageConfigurationResponse(ctx context.Context, k8sStateStorageConfiguration canyoncp.K8sStorageConfiguration) (*basetypes.ObjectValue, error) {
 	var stateStorageConfig commonRunnerStateStorageModel
 
 	stateStorageConfig.Type = string(k8sStateStorageConfiguration.Type)
@@ -34,10 +33,9 @@ func parseStateStorageConfigurationResponse(ctx context.Context, k8sStateStorage
 
 	objectValue, diags := types.ObjectValueFrom(ctx, commonStateStorageConfigurationAttributes(), stateStorageConfig)
 	if diags.HasError() {
-		tflog.Warn(ctx, "can't parse state storage configuration from model", map[string]interface{}{"err": diags.Errors()})
-		return nil
+		return nil, fmt.Errorf("failed to build state storage configuration from model parsing API response: %v", diags.Errors())
 	}
-	return &objectValue
+	return &objectValue, nil
 }
 
 func createStateStorageConfigurationFromObject(ctx context.Context, obj types.Object) (canyoncp.StateStorageConfiguration, error) {

--- a/internal/provider/runner_helpers.go
+++ b/internal/provider/runner_helpers.go
@@ -28,7 +28,9 @@ func parseStateStorageConfigurationResponse(ctx context.Context, k8sStateStorage
 	var stateStorageConfig commonRunnerStateStorageModel
 
 	stateStorageConfig.Type = string(k8sStateStorageConfiguration.Type)
-	stateStorageConfig.KubernetesConfiguration.Namespace = k8sStateStorageConfiguration.Namespace
+	stateStorageConfig.KubernetesConfiguration = &commonRunnerKubernetesStateStorageModel{
+		Namespace: k8sStateStorageConfiguration.Namespace,
+	}
 
 	objectValue, diags := types.ObjectValueFrom(ctx, commonStateStorageConfigurationAttributes(), stateStorageConfig)
 	if diags.HasError() {

--- a/internal/provider/runner_helpers.go
+++ b/internal/provider/runner_helpers.go
@@ -20,6 +20,12 @@ func commonStateStorageConfigurationAttributes() map[string]attr.Type {
 				"namespace": types.StringType,
 			},
 		},
+		"s3": types.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"bucket":      types.StringType,
+				"path_prefix": types.StringType,
+			},
+		},
 	}
 }
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1,6 +1,10 @@
 package provider
 
 import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -20,4 +24,51 @@ func toStringValueOrNil(str *string) basetypes.StringValue {
 		return types.StringNull()
 	}
 	return types.StringValue(*str)
+}
+
+// AttributeTypeFromResourceSchemaAttr returns the attribute type for the given schema attribute.
+func AttributeTypeFromResourceSchemaAttr(a schema.Attribute) (attr.Type, error) {
+	switch typed := a.(type) {
+	case schema.StringAttribute:
+		return types.StringType, nil
+	case schema.BoolAttribute:
+		return types.BoolType, nil
+	case schema.Float64Attribute:
+		return types.Float64Type, nil
+	case schema.Float32Attribute:
+		return types.Float32Type, nil
+	case schema.Int64Attribute:
+		return types.Int64Type, nil
+	case schema.Int32Attribute:
+		return types.Int32Type, nil
+	case schema.NumberAttribute:
+		return types.NumberType, nil
+	case schema.MapAttribute:
+		return types.MapType{
+			ElemType: typed.ElementType,
+		}, nil
+	case schema.ListAttribute:
+		return types.ListType{
+			ElemType: typed.ElementType,
+		}, nil
+	case schema.SingleNestedAttribute:
+		attrs, err := AttributeTypesFromResourceSchema(typed.Attributes)
+		return types.ObjectType{AttrTypes: attrs}, err
+	default:
+		// NOTE: add more cases as needed
+		return nil, fmt.Errorf("unsupported attribute type for '%v': %T", a, typed)
+	}
+}
+
+// AttributeTypesFromResourceSchema returns the attribute types map for the given schema.
+func AttributeTypesFromResourceSchema(attributes map[string]schema.Attribute) (map[string]attr.Type, error) {
+	attrTypes := make(map[string]attr.Type, len(attributes))
+	for k, v := range attributes {
+		attrType, err := AttributeTypeFromResourceSchemaAttr(v)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", k, err)
+		}
+		attrTypes[k] = attrType
+	}
+	return attrTypes, nil
 }


### PR DESCRIPTION
All runners are able to use the s3 backend type now to store TF state in a remote s3 bucket. 

The configuration is starting very very simple: only the bucket name is required, the rest of the configuration (region, auth, path_prefix, etc are either optional, or can be provided through the credentials accessible within the runner.

This does touch a number of files since it supports this in all the runners which then updates all the runner documentation as well.

```hcl
resource "platform-orchestrator_kubernetes_agent_runner" "test" {
  id = "my-runner"
  runner_configuration = {
	key = "....>"
	job = {
	  namespace = "default"
	  service_account = "humanitec-runner"
	}
  }
  state_storage_configuration = {
	type = "s3"
	s3_configuration = {
	  bucket = "some-bucket"
	  path_prefix = "some/prefix"
	}
  }
}
```

Video walkthrough

[![Loom Video Thumbnail](https://cdn.loom.com/sessions/thumbnails/ee7ad4780acd4ecdaba94e0b38a64057-e802f3453475718b-full-play.gif)](https://www.loom.com/share/ee7ad4780acd4ecdaba94e0b38a64057)